### PR TITLE
Fix test issues and lazy import heavy modules

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -51,8 +51,8 @@ def classify(arg: str):
                     model_dir=repo)
     # open-weight HF
     repo = arg.replace("https://huggingface.co/", "").rstrip("/")
-    safe_name = repo.replace("/", "_")
-    return dict(model_family="open-hf", model_id=safe_name, model_dir=repo)
+    model_id = repo.split("/")[-1]
+    return dict(model_family="open-hf", model_id=model_id, model_dir=repo)
 
 def run(cmd):
     print("\n$ " + " ".join(cmd), flush=True)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -91,11 +91,8 @@ def test_evaluate_stub(tmp_path, monkeypatch):
     meta.write_text("{}")
 
     cfg = tmp_path / "c.yaml"
-    cfg.write_text(f"""\
-model_family: open-hf
-
-    cfg = tmp_path / "c.yaml"
-    cfg.write_text(f"""\
+    cfg.write_text(
+        f"""\
 model_family: open-hf
 model_id: mock
 model_dir: mock
@@ -103,7 +100,8 @@ dataset:
   type: text-vqa-slim
   root_dir: {tmp_path}
 results_dir: {tmp_path}
-""")
+"""
+    )
 
     monkeypatch.chdir(REPO_ROOT)
     import scripts.evaluate as ev

--- a/vlm_eval/models/__init__.py
+++ b/vlm_eval/models/__init__.py
@@ -1,25 +1,29 @@
 from pathlib import Path
 from typing import Optional
 
+from importlib import import_module
 from vlm_eval.util.interfaces import VLM
 
-from .instructblip import InstructBLIP
-#from .llava import LLaVa
-from .prismatic import PrismaticVLM
-from .open_hf import OpenHF
-from .anthropic_loader import AnthropicVLM
-from .google_loader import GeminiVLM
-from .janus import JanusVLM
-
-# === Initializer Dispatch by Family ===
-FAMILY2INITIALIZER = {
-    "instruct-blip": InstructBLIP,
-    "prismatic":      PrismaticVLM,
-    "open-hf":        OpenHF,
-    "anthropic":      AnthropicVLM,
-    "google":         GeminiVLM,
-    "janus": JanusVLM
+# Avoid importing heavy deps unless needed
+_FAMILY2MODULE = {
+    "instruct-blip": ("vlm_eval.models.instructblip", "InstructBLIP"),
+    "prismatic": ("vlm_eval.models.prismatic", "PrismaticVLM"),
+    "open-hf": ("vlm_eval.models.open_hf", "OpenHF"),
+    "anthropic": ("vlm_eval.models.anthropic_loader", "AnthropicVLM"),
+    "google": ("vlm_eval.models.google_loader", "GeminiVLM"),
+    "janus": ("vlm_eval.models.janus", "JanusVLM"),
 }
+
+# Initializer dispatch table (values lazily filled)
+FAMILY2INITIALIZER = {k: None for k in _FAMILY2MODULE}
+
+def _get_initializer(family: str):
+    if FAMILY2INITIALIZER[family] is None:
+        mod_name, cls_name = _FAMILY2MODULE[family]
+        mod = import_module(mod_name)
+        FAMILY2INITIALIZER[family] = getattr(mod, cls_name)
+    return FAMILY2INITIALIZER[family]
+
 
 def load_vlm(
     model_family: str,
@@ -35,8 +39,9 @@ def load_vlm(
         # ------------------------------------------------------------------
         # Pass the **full repo-id** (run_dir) to OpenHF as its first arg
         # ------------------------------------------------------------------
-        return OpenHF(
-            str(run_dir),                 # <— deepseek-ai/Janus-Pro-7B
+        cls = _get_initializer("open-hf")
+        return cls(
+            str(run_dir),
             hf_token=hf_token,
             load_precision=load_precision,
             max_length=max_length,
@@ -45,9 +50,10 @@ def load_vlm(
         )
 
     # all other families stay unchanged
-    assert model_family in FAMILY2INITIALIZER, \
+    assert model_family in _FAMILY2MODULE, \
         f"Model family `{model_family}` not supported!"
-    return FAMILY2INITIALIZER[model_family](
+    cls = _get_initializer(model_family)
+    return cls(
         model_family=model_family,
         model_id=model_id,
         run_dir=run_dir,

--- a/vlm_eval/util/interfaces.py
+++ b/vlm_eval/util/interfaces.py
@@ -5,9 +5,14 @@ Protocol/type definitions for the common parts of the VLM training & inference p
 (e.g., ImageProcessors) to complete vision-language models (VLMs).
 """
 from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple, Union
+import types
 
-import torch
-import torch.nn as nn
+try:  # Optional dependency for type hints only
+    import torch
+    import torch.nn as nn
+except ModuleNotFoundError:  # pragma: no cover - allow lightweight test env
+    torch = types.SimpleNamespace(Tensor=object)
+    nn = types.SimpleNamespace(Module=object)
 from PIL.Image import Image
 from transformers.tokenization_utils import BatchEncoding
 


### PR DESCRIPTION
## Summary
- fix broken YAML stub in `tests/test_repo.py`
- use lazy imports in `vlm_eval.models` to avoid heavy dependency import errors
- make `interfaces` resilient when `torch` isn't installed
- correct `classify` open model ID handling in `run_all`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aec15044832da582ceaf95f5627a